### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for interacting with the DeepWriter API. This server provides tools for creating, managing, and generating content for DeepWriter projects through the standardized MCP interface.
 
+<a href="https://glama.ai/mcp/servers/@deepwriter-ai/Deepwriter-MCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@deepwriter-ai/Deepwriter-MCP/badge" alt="DeepWriter Server MCP server" />
+</a>
+
 ## Features
 
 - **Project Management**: Create, list, update, and delete projects


### PR DESCRIPTION
This PR adds a badge for the [DeepWriter MCP Server](https://glama.ai/mcp/servers/@deepwriter-ai/Deepwriter-MCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@deepwriter-ai/Deepwriter-MCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@deepwriter-ai/Deepwriter-MCP/badge" alt="DeepWriter Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.